### PR TITLE
feat[7/361/68]: services-4 | favorite hotel list and toggle favorite status added

### DIFF
--- a/src/app/api/favorite/index.ts
+++ b/src/app/api/favorite/index.ts
@@ -1,1 +1,2 @@
+export { IFavoriteResponse } from './favorite-api.interface';
 export { FavoriteApiService } from './favorite-api.service';

--- a/src/app/interfaces/index.ts
+++ b/src/app/interfaces/index.ts
@@ -1,5 +1,6 @@
 export { ICity } from './city.interface';
 export { IComment } from './comment.interface';
 export { IHotel } from './hotel.interface';
+export { IList } from './list.interface';
 export { ILocation } from './location.interface';
 export { IUser } from './user.interface';

--- a/src/app/interfaces/list.interface.ts
+++ b/src/app/interfaces/list.interface.ts
@@ -1,0 +1,3 @@
+export interface IList<Type> {
+  list: Type[];
+}

--- a/src/app/services/city/city.service.spec.ts
+++ b/src/app/services/city/city.service.spec.ts
@@ -7,16 +7,28 @@ import { ICity } from '@interfaces';
 import { CityService } from './city.service';
 
 
-const city: ICity = {
-  id: `023dda52-f07b-47ef-a44c-2301f8743149`,
-  title: `Amsterdam`,
-  location: {
-    id: `0b88066e-c543-451f-b4a0-67c0729335da`,
-    latitude: 53.550341,
-    longitude: 10.000654,
-    zoom: 8,
+const cityList: ICity[] = [
+  {
+    id: `023dda52-f07b-47ef-a44c-2301f8743149`,
+    title: `Amsterdam`,
+    location: {
+      id: `0b88066e-c543-451f-b4a0-67c0729335da`,
+      latitude: 53.550341,
+      longitude: 10.000654,
+      zoom: 8,
+    },
   },
-};
+  {
+    id: `a38df743-3355-4c81-ba10-912f7e19edf7`,
+    title: `Brussels`,
+    location: {
+      id: `a5737932-bcf7-4440-ab89-fd3dff68ccea`,
+      latitude: 50.846557,
+      longitude: 4.351697,
+      zoom: 13
+    },
+  },
+];
 
 describe('CityService', () => {
   let service: CityService;
@@ -28,7 +40,7 @@ describe('CityService', () => {
         {
           provide: CityApiService,
           useValue: {
-            loadList: () => of([city])
+            loadList: () => of(cityList)
           }
         }
       ]
@@ -41,10 +53,31 @@ describe('CityService', () => {
   });
 
   it(`should get city list when service init`, () => {
-    let cityList = [];
+    let currentCityList = [];
     service.cityList$.subscribe((newCityList: ICity[]) => {
-      cityList = newCityList;
+      currentCityList = newCityList;
     });
-    expect(cityList).toEqual([city]);
+    expect(currentCityList).toEqual(cityList);
+  });
+
+  describe(`switchCity`, () => {
+    it(`shouldn't have a city by default`, () => {
+      let city: ICity;
+      service.city$.subscribe((newCity: ICity) => {
+        city = newCity;
+      });
+      expect(city).toBeUndefined();
+    });
+
+    it(`should switch a city before call switchCity method`, () => {
+      let city: ICity;
+      service.city$.subscribe((newCity: ICity) => {
+        city = newCity;
+      });
+      service.switchCity(cityList[0].id);
+      expect(city).toEqual(cityList[0]);
+      service.switchCity(cityList[1].id);
+      expect(city).toEqual(cityList[1]);
+    });
   });
 });

--- a/src/app/services/city/city.service.ts
+++ b/src/app/services/city/city.service.ts
@@ -6,17 +6,42 @@ import {
 
 import { CityApiService } from '@api';
 import { ICity } from '@interfaces';
+import {
+  first,
+  map
+} from 'rxjs/operators';
 
 
 @Injectable({
   providedIn: 'root'
 })
 export class CityService {
+  private readonly _cityReplaySubject: ReplaySubject<ICity> = new ReplaySubject(1);
+  public readonly city$: Observable<ICity> = this._cityReplaySubject.asObservable();
+
   private readonly _cityListReplaySubject: ReplaySubject<ICity[]> = new ReplaySubject(1);
-  public cityList$: Observable<ICity[]> = this._cityListReplaySubject.asObservable() as Observable<ICity[]>;
+  public readonly cityList$: Observable<ICity[]> = this._cityListReplaySubject.asObservable() as Observable<ICity[]>;
 
 
   constructor(private readonly _cityApiService: CityApiService) {
-    this._cityApiService.loadList().subscribe((cityList: ICity[]) => this._cityListReplaySubject.next(cityList));
+    this._cityApiService
+      .loadList()
+      .subscribe((cityList: ICity[]) =>
+        this._cityListReplaySubject.next(cityList)
+      );
+  }
+
+
+  public switchCity(cityId: string): void {
+    this.cityList$
+      .pipe(
+        first(),
+        map((cityList: ICity[]) =>
+          cityList.find((city) => city.id === cityId)
+        )
+      )
+      .subscribe((city: ICity) =>
+        this._cityReplaySubject.next(city)
+      );
   }
 }

--- a/src/app/services/hotel/hotel.service.spec.ts
+++ b/src/app/services/hotel/hotel.service.spec.ts
@@ -3,18 +3,50 @@ import { of } from 'rxjs';
 
 import {
   ApiModule,
+  CityApiService,
   ESortingType,
-  HotelApiService
+  FavoriteApiService,
+  HotelApiService,
+  IFavoriteResponse
 } from '@api';
-import { IHotel } from '@interfaces';
+import {
+  ICity,
+  IHotel,
+  IList
+} from '@interfaces';
 
 import { HotelService } from './hotel.service';
+import { CityService } from '../city';
 
 
-const cityId = `067564fe-3fce-4e11-add6-7ed402979819`;
+const cityList: ICity[] = [
+  {
+    id: `023dda52-f07b-47ef-a44c-2301f8743149`,
+    title: `Amsterdam`,
+    location: {
+      id: `0b88066e-c543-451f-b4a0-67c0729335da`,
+      latitude: 53.550341,
+      longitude: 10.000654,
+      zoom: 8,
+    },
+  },
+  {
+    id: `a38df743-3355-4c81-ba10-912f7e19edf7`,
+    title: `Brussels`,
+    location: {
+      id: `a5737932-bcf7-4440-ab89-fd3dff68ccea`,
+      latitude: 50.846557,
+      longitude: 4.351697,
+      zoom: 13
+    },
+  },
+];
+
+
+const hotelId = `023dda52-f07b-47ef-a44c-2301f8743149`;
 
 const hotel: IHotel = {
-  id: `240d821a-b2e5-437f-afb9-7e840eafba81`,
+  id: hotelId,
   title: `The Joshua Tree House`,
   description: `A new spacious villa, one floor. All commodities, jacuzzi and beautiful scenery. Ideal for families or friends.`,
   bedroomCount: 3,
@@ -29,14 +61,14 @@ const hotel: IHotel = {
   ],
   type: `house`,
   city: {
-    id: cityId,
-    title: `Hamburg`,
+    id: `023dda52-f07b-47ef-a44c-2301f8743149`,
+    title: `Amsterdam`,
     location: {
-      id: `56d78420-03b3-4f1d-b86f-387e00968f8c`,
+      id: `0b88066e-c543-451f-b4a0-67c0729335da`,
       latitude: 53.550341,
       longitude: 10.000654,
-      zoom: 13
-    }
+      zoom: 8,
+    },
   },
   location: {
     id: `20fbab8c-1766-4cd5-bf9e-e059bd9ccbe7`,
@@ -56,9 +88,17 @@ const hotel: IHotel = {
   isFavorite: false
 };
 
+const favorite: IFavoriteResponse = {
+  hotelId,
+  userId: `0b88066e-c543-451f-b4a0-67c0729335da`,
+  value: true,
+};
+
 describe('HotelService', () => {
   let service: HotelService;
   let hotelApiService: HotelApiService;
+  let favoriteApiService: FavoriteApiService;
+  let cityService: CityService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -67,14 +107,28 @@ describe('HotelService', () => {
         {
           provide: HotelApiService,
           useValue: {
-            loadList: () => of([hotel]),
+            loadList: () => of([Object.assign({}, hotel)]),
             loadItemById: () => of(hotel),
+          },
+        },
+        {
+          provide: FavoriteApiService,
+          useValue: {
+            toggleFavoriteStatus: () => of(favorite),
+          },
+        },
+        {
+          provide: CityApiService,
+          useValue: {
+            loadList: () => of(cityList),
           }
         }
       ],
     });
     service = TestBed.inject(HotelService);
     hotelApiService = TestBed.inject(HotelApiService);
+    favoriteApiService = TestBed.inject(FavoriteApiService);
+    cityService = TestBed.inject(CityService);
   });
 
   it('should be created', () => {
@@ -82,36 +136,57 @@ describe('HotelService', () => {
   });
 
   describe(`updateList`, () => {
+    beforeEach(() => {
+      cityService.switchCity(cityList[0].id);
+    });
+
     it(`should call loadList of HotelApiService if haven't hotel list for current sorting, city and pack`, () => {
       const loadList = spyOn(hotelApiService, `loadList`).and.callThrough();
-      service.updateList(cityId, ESortingType.POPULAR);
-      service.updateList(cityId, ESortingType.RATING);
-      service.updateList(`0750092a-061b-463e-a262-3f77146aec66`, ESortingType.RATING);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
+      service.updateList({
+        sorting: ESortingType.RATING,
+      });
+      cityService.switchCity(cityList[1].id);
+      service.updateList({
+        sorting: ESortingType.RATING,
+      });
       expect(loadList).toHaveBeenCalledTimes(3);
     });
 
     it(`shouldn't call loadList of HotelApiService if has hotel list for current sorting, city and pack`, () => {
       const loadList = spyOn(hotelApiService, `loadList`).and.callThrough();
-      service.updateList(cityId, ESortingType.POPULAR);
-      service.updateList(cityId, ESortingType.POPULAR);
-      service.updateList(cityId, ESortingType.POPULAR);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
       expect(loadList).toHaveBeenCalledTimes(1);
     });
 
     it(`should emit hotelList`, () => {
       let hotelList: IHotel[] = [];
-      service.hotelList$.subscribe((newHotelList: IHotel[]) => {
-        hotelList = newHotelList;
+      service.hotelParams$.subscribe((hotelParams: IList<IHotel>) => {
+        hotelList = hotelParams.list;
       });
-      service.updateList(cityId, ESortingType.POPULAR);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
       expect(hotelList).toEqual([hotel]);
     });
 
     it(`should call loadList of HotelApiService with correct params`, () => {
       const loadList = spyOn(hotelApiService, `loadList`).and.callThrough();
-      service.updateList(cityId, ESortingType.POPULAR);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
       expect(loadList).toHaveBeenCalledWith({
-        cityId,
+        cityId: cityList[0].id,
         sorting: ESortingType.POPULAR,
       });
     });
@@ -131,7 +206,9 @@ describe('HotelService', () => {
       });
       [ESortingType.RATING, ESortingType.POPULAR, ESortingType.HIGH_PRICE, ESortingType.LOW_PRICE]
         .forEach((emittedSorting: ESortingType) => {
-          service.updateList(cityId, emittedSorting);
+          service.updateList({
+            sorting: emittedSorting,
+          });
           expect(sorting).toEqual(emittedSorting);
         });
     });
@@ -173,6 +250,69 @@ describe('HotelService', () => {
         hotelId: hotel.id,
         sorting: ESortingType.NEARBY,
       });
+    });
+  });
+
+  describe(`loadFavoriteHotels`, () => {
+    it(`should call loadList of HotelApiService`, () => {
+      const loadList = spyOn(hotelApiService, `loadList`).and.callThrough();
+      service.loadFavoriteHotels();
+      expect(loadList).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should call loadList of HotelApiService with params`, () => {
+      const loadList = spyOn(hotelApiService, `loadList`).and.callThrough();
+      service.loadFavoriteHotels();
+      expect(loadList).toHaveBeenCalledWith({
+        isFavorite: true,
+      });
+    });
+
+    it(`should emit favorite hotel list`, () => {
+      let hotelList: IHotel[] = [];
+      service.favoriteHotelList$.subscribe((favoriteHotelList: IHotel[]) => {
+        hotelList = favoriteHotelList;
+      });
+      service.loadFavoriteHotels();
+      expect(hotelList).toEqual([hotel]);
+    });
+  });
+
+  describe(`toggleFavoriteStatus`, () => {
+    it(`should call toggleFavoriteStatus method of FavoriteApiService`, () => {
+      const toggleFavoriteStatus = spyOn(favoriteApiService, `toggleFavoriteStatus`).and.callThrough();
+      service.toggleFavoriteStatus(hotelId);
+      expect(toggleFavoriteStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should toggle favorite status in all contained hotel maps`, () => {
+      let hotelList: IHotel[] = [];
+      service.hotelParams$.subscribe((hotelParams: IList<IHotel>) => {
+        hotelList = hotelParams.list;
+      });
+      cityService.switchCity(cityList[0].id);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
+      expect(hotelList[0].isFavorite).toBeFalsy();
+      cityService.switchCity(cityList[1].id);
+      service.updateList({
+        sorting: ESortingType.LOW_PRICE,
+      });
+      expect(hotelList[0].isFavorite).toBeFalsy();
+
+      service.toggleFavoriteStatus(hotelId);
+
+      cityService.switchCity(cityList[0].id);
+      service.updateList({
+        sorting: ESortingType.POPULAR,
+      });
+      expect(hotelList[0].isFavorite).toBeTruthy();
+      cityService.switchCity(cityList[1].id);
+      service.updateList({
+        sorting: ESortingType.LOW_PRICE,
+      });
+      expect(hotelList[0].isFavorite).toBeTruthy();
     });
   });
 });

--- a/src/app/services/hotel/hotel.service.ts
+++ b/src/app/services/hotel/hotel.service.ts
@@ -2,66 +2,104 @@ import { Injectable } from '@angular/core';
 import {
   BehaviorSubject,
   Observable,
+  of,
   ReplaySubject
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  first,
+  map,
+  mergeMap
+} from 'rxjs/operators';
 
 import {
   ESortingType,
-  HotelApiService
+  FavoriteApiService,
+  HotelApiService,
+  IFavoriteResponse
 } from '@api';
-import { IHotel } from '@interfaces';
+import {
+  ICity,
+  IHotel,
+  IList
+} from '@interfaces';
+import { CityService } from '../city';
 
 
 const NEARBY_HOTEL_COUNT = 3;
+
+export interface IHotelUpdateParams {
+  sorting: ESortingType;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class HotelService {
-  private _hotelMap: Map<string, Map<ESortingType, IHotel[]>> = new Map([]);
+  private _hotelMap: Map<string, Map<ESortingType, IList<IHotel>>> = new Map([]);
 
-  private _hotelListReplaySubject: ReplaySubject<IHotel[]> = new ReplaySubject(1);
-  public hotelList$: Observable<IHotel[]> = this._hotelListReplaySubject.asObservable();
+  private _hotelParamsReplaySubject: ReplaySubject<IList<IHotel>> = new ReplaySubject(1);
+  public hotelParams$: Observable<IList<IHotel>> = this._hotelParamsReplaySubject.asObservable();
+
+  private _favoriteHotelListBehaviorSubject: BehaviorSubject<IHotel[]> = new BehaviorSubject([]);
+  public favoriteHotelList$: Observable<IHotel[]> = this._favoriteHotelListBehaviorSubject.asObservable();
 
   private _sortingBehaviorSubject: BehaviorSubject<ESortingType> = new BehaviorSubject(ESortingType.POPULAR);
   public sorting$: Observable<ESortingType> = this._sortingBehaviorSubject.asObservable();
 
 
-  constructor(private readonly _hotelApiService: HotelApiService) { }
+  constructor(
+    private readonly _hotelApiService: HotelApiService,
+    private readonly _favoriteApiService: FavoriteApiService,
+    private readonly _cityService: CityService,
+  ) {
+  }
 
 
-  public updateList(cityId: string, sorting: ESortingType): void {
-    const hotelList: IHotel[] = this._hotelMap.get(cityId)?.get(sorting);
-    if (hotelList) {
-      this._hotelListReplaySubject.next(hotelList);
-    } else {
-      this._loadHotelList(cityId, sorting);
-    }
+  public updateList(params: IHotelUpdateParams): void {
+    const { sorting } = params;
     this._sortingBehaviorSubject.next(sorting);
+    this._cityService.city$
+      .pipe(
+        first(),
+        mergeMap((city: ICity) => {
+          const hotelParams: IList<IHotel> = this._hotelMap.get(city.id)?.get(sorting);
+          if (hotelParams) {
+            return of({city, hotelParams});
+          } else {
+            return this._hotelApiService
+              .loadList({
+                cityId: city.id,
+                sorting,
+              })
+              .pipe(
+                map((hotelList: IHotel[]) => ({
+                  city,
+                  hotelParams: {
+                    list: hotelList,
+                  },
+                }))
+              );
+          }
+        })
+      )
+      .subscribe(({city, hotelParams}) => {
+        const cityHotelMap = this._hotelMap.get(city.id);
+        if (cityHotelMap) {
+          cityHotelMap.set(sorting, hotelParams);
+        } else {
+          this._hotelMap.set(city.id, new Map([
+            [sorting, hotelParams],
+          ]));
+        }
+        this._hotelParamsReplaySubject.next(hotelParams);
+      });
   }
 
-
-  private _loadHotelList(cityId: string, sorting: ESortingType): void {
-    this._hotelApiService.loadList({
-      cityId,
-      sorting,
-    }).subscribe((hotelList: IHotel[]) => {
-      const cityHotelMap = this._hotelMap.get(cityId);
-      if (cityHotelMap) {
-        cityHotelMap.set(sorting, hotelList);
-      } else {
-        this._hotelMap.set(cityId, new Map([
-          [sorting, hotelList],
-        ]));
-      }
-      this._hotelListReplaySubject.next(hotelList);
-    });
-  }
 
   public loadHotel(hotelId: string): Observable<IHotel> {
     return this._hotelApiService.loadItemById(hotelId);
   }
+
 
   public loadNearestHotels(hotelId: string): Observable<IHotel[]> {
     return this._hotelApiService
@@ -72,5 +110,57 @@ export class HotelService {
       .pipe(
         map((hotelList: IHotel[]) => hotelList.slice(0, NEARBY_HOTEL_COUNT))
       );
+  }
+
+
+  public loadFavoriteHotels(): void {
+    this._hotelApiService
+      .loadList({
+        isFavorite: true,
+      })
+      .subscribe((favoriteHotelList: IHotel[]) => {
+        this._favoriteHotelListBehaviorSubject.next(favoriteHotelList);
+      });
+  }
+
+
+  public toggleFavoriteStatus(hotelId: string): void {
+    this._favoriteApiService
+      .toggleFavoriteStatus(hotelId)
+      .subscribe((favorite: IFavoriteResponse) => {
+        this._updateHotelMaps(favorite.hotelId, {isFavorite: favorite.value});
+        this._updateFavoriteHotel(favorite.hotelId, {isFavorite: favorite.value});
+      });
+  }
+
+
+  public _updateHotelMaps(hotelId: string, updatedHotelParams: Partial<IHotel>): void {
+    const updatedParamNames = Object.keys(updatedHotelParams);
+    this._hotelMap.forEach((cityHotelMaps: Map<ESortingType, IList<IHotel>>) => {
+      cityHotelMaps.forEach((sortingHotels: IList<IHotel>) => {
+        sortingHotels.list.forEach((hotel: IHotel) => {
+          if (hotel.id !== hotelId) {
+            return;
+          }
+          updatedParamNames.forEach((paramName: string) => {
+            hotel[paramName] = updatedHotelParams[paramName];
+          });
+        });
+      });
+    });
+  }
+
+
+  public _updateFavoriteHotel(hotelId: string, updatedHotelParams: Partial<IHotel>): void {
+    const updatedParamNames = Object.keys(updatedHotelParams);
+    const favoriteHotel = this._favoriteHotelListBehaviorSubject
+      .getValue()
+      .find((hotel: IHotel) => hotel.id === hotelId);
+    if (!favoriteHotel) {
+      return;
+    }
+    updatedParamNames.forEach((paramName: string) => {
+      favoriteHotel[paramName] = updatedHotelParams[paramName];
+    });
   }
 }


### PR DESCRIPTION
<h3>City Service</h3>

new methods: 
- `switchCity(cityId)` - switch active city by id;

new streams:
- `city$` - current city.


<h3>Hotel Service</h3>

updated methods:
- updateList(params) - added logic for getting `cityId`

new methods:
- `toggleFavoriteStatus(hotelId)` - toggle favorite status for hotel with selected `id`;
- `loadFavoriteList()` - load favorite list for authorized user;

streams:
- `favoriteHotelList$` - stream of favorite hotel list